### PR TITLE
Set run_exports max_pin to x.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,9 @@ source:
     - 0001-remove-wil-from-exported-config.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
-    - {{ pin_subpackage("azure-core-cpp", max_pin="x") }}
+    - {{ pin_subpackage("azure-core-cpp", max_pin="x.x") }}
 
 # https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core/vcpkg.json
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

When we originally added the Azure SDK for C++ libraries to conda-forge, we decided to set `max_pin="x"` (https://github.com/conda-forge/staged-recipes/pull/23297#discussion_r1286176457). This was for two primary motivations:

1. Upstream said that minor versions were backwards compatible
2. Strict run_exports make it much more difficult for the conda solver to find a valid environment. Thus we want to be as permissive as possible

However, we recently had our first consequence of this loose pinning. azure-core-cpp 1.11.0 is breaking `tiledb` conda binaries that were built against azure-core-cpp 1.10.3 (https://github.com/conda-forge/tiledb-feedstock/issues/228).

This is a draft. **Please do not merge.** We need time for:

- [x] Allow for discussion and obtain approvals from multiple maintainers. The alternative to this PR is to keep the loose pin and hope that these breaking changes in minor releases are rare. Making `max_pin` more strict also has consequences on recipe maintenance. Recipes that build against azure-core-cpp will have to be rebuilt more regularly if they want to use the latest azure-core-cpp, and if enough recipes start depending on it, we'll need to add it to conda-forge-pinning
- [x] I need to submit a repodata patch for the currently uploaded `tiledb` to pin `azure-core-cpp <1.11`. If this was merged before this, that would once again break `tiledb`

And thinking longer-term: should we also update the `max_pin` for the other `azure-*-cpp` recipes? Or should we wait until they actually break backwards compatibility first? My current vote would be to wait on the other recipes, due to the extra solver constraints and maintenance of downstream recipes if we bump `max_bin="x.x"