### PR TITLE
Use run_exports max_pin of x.x.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,9 @@ source:
     - 0001-remove-wil-from-exported-config.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
-    - {{ pin_subpackage("azure-core-cpp", max_pin="x.x") }}
+    - {{ pin_subpackage("azure-core-cpp", max_pin="x.x.x") }}
 
 # https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core/vcpkg.json
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

We recently learned from the upstream Azure SDK for C++ maintainers that we should not expect binary compatibility between any Azure C++ library releases (https://github.com/Azure/azure-sdk-for-cpp/issues/5322, https://github.com/conda-forge/azure-core-cpp-feedstock/pull/11#issuecomment-1927972737)

My plan is to roll out `max_pin="x.x.x"` throughout the dependency network of Azure C++ libraries we have on conda-forge. Once that is completed, we can consider submitting a repodata patch to increase the max_pin for all existing Azure binaries.
